### PR TITLE
Update deprecated getters and setters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 # Dock Spawn Authors
 
 Ali Akbar <ali.akbar@gmail.com>
+Marius Volkhart <marius@volkhart.com>

--- a/lib/containers/fill_dock_container.dart
+++ b/lib/containers/fill_dock_container.dart
@@ -55,10 +55,10 @@ class FillDockContainer implements IDockContainer {
   }
 
   
-  int get width => element.clientWidth;
+  int get width => element.$dom_clientWidth;
   set width(int value) => element.style.width = "${value}px";
   
-  int get height => element.clientHeight;
+  int get height => element.$dom_clientHeight;
   set height(int value) => element.style.height = "${value}px";
   
 }

--- a/lib/containers/fill_dock_container.dart
+++ b/lib/containers/fill_dock_container.dart
@@ -55,10 +55,10 @@ class FillDockContainer implements IDockContainer {
   }
 
   
-  int get width => element.clientWidth;
+  int get width => element.client.width;
   set width(int value) => element.style.width = "${value}px";
   
-  int get height => element.clientHeight;
+  int get height => element.client.height;
   set height(int value) => element.style.height = "${value}px";
   
 }

--- a/lib/containers/fill_dock_container.dart
+++ b/lib/containers/fill_dock_container.dart
@@ -55,10 +55,10 @@ class FillDockContainer implements IDockContainer {
   }
 
   
-  int get width => element.$dom_clientWidth;
+  int get width => element.clientWidth;
   set width(int value) => element.style.width = "${value}px";
   
-  int get height => element.$dom_clientHeight;
+  int get height => element.clientHeight;
   set height(int value) => element.style.height = "${value}px";
   
 }

--- a/lib/containers/panel_dock_container.dart
+++ b/lib/containers/panel_dock_container.dart
@@ -90,9 +90,9 @@ class PanelContainer implements IDockContainer {
     elementContentHost.classes.add("panel-content");
     
     // set the size of the dialog elements based on the panel's size
-    int panelWidth = elementContent.clientWidth; 
-    int panelHeight = elementContent.clientHeight; 
-    int titleHeight = elementTitle.clientHeight; 
+    int panelWidth = elementContent.client.width; 
+    int panelHeight = elementContent.client.height; 
+    int titleHeight = elementTitle.client.height; 
     _setPanelDimensions(panelWidth, panelHeight + titleHeight);
     
     // Add the panel to the body
@@ -179,7 +179,7 @@ class PanelContainer implements IDockContainer {
     elementPanel.style.width = "${_width}px";
 
 
-    int titleBarHeight = elementTitle.clientHeight;
+    int titleBarHeight = elementTitle.client.height;
     int contentHeight = _height - titleBarHeight;
     elementContentHost.style.height = "${contentHeight}px";
     elementContent.style.height = "${contentHeight}px";

--- a/lib/containers/panel_dock_container.dart
+++ b/lib/containers/panel_dock_container.dart
@@ -90,9 +90,9 @@ class PanelContainer implements IDockContainer {
     elementContentHost.classes.add("panel-content");
     
     // set the size of the dialog elements based on the panel's size
-    int panelWidth = elementContent.clientWidth; 
-    int panelHeight = elementContent.clientHeight; 
-    int titleHeight = elementTitle.clientHeight; 
+    int panelWidth = elementContent.$dom_clientWidth; 
+    int panelHeight = elementContent.$dom_clientHeight; 
+    int titleHeight = elementTitle.$dom_clientHeight; 
     _setPanelDimensions(panelWidth, panelHeight + titleHeight);
     
     // Add the panel to the body
@@ -179,7 +179,7 @@ class PanelContainer implements IDockContainer {
     elementPanel.style.width = "${_width}px";
 
 
-    int titleBarHeight = elementTitle.clientHeight;
+    int titleBarHeight = elementTitle.$dom_clientHeight;
     int contentHeight = _height - titleBarHeight;
     elementContentHost.style.height = "${contentHeight}px";
     elementContent.style.height = "${contentHeight}px";

--- a/lib/containers/panel_dock_container.dart
+++ b/lib/containers/panel_dock_container.dart
@@ -90,9 +90,9 @@ class PanelContainer implements IDockContainer {
     elementContentHost.classes.add("panel-content");
     
     // set the size of the dialog elements based on the panel's size
-    int panelWidth = elementContent.$dom_clientWidth; 
-    int panelHeight = elementContent.$dom_clientHeight; 
-    int titleHeight = elementTitle.$dom_clientHeight; 
+    int panelWidth = elementContent.clientWidth; 
+    int panelHeight = elementContent.clientHeight; 
+    int titleHeight = elementTitle.clientHeight; 
     _setPanelDimensions(panelWidth, panelHeight + titleHeight);
     
     // Add the panel to the body
@@ -179,7 +179,7 @@ class PanelContainer implements IDockContainer {
     elementPanel.style.width = "${_width}px";
 
 
-    int titleBarHeight = elementTitle.$dom_clientHeight;
+    int titleBarHeight = elementTitle.clientHeight;
     int contentHeight = _height - titleBarHeight;
     elementContentHost.style.height = "${contentHeight}px";
     elementContent.style.height = "${contentHeight}px";

--- a/lib/containers/splitter_dock_container.dart
+++ b/lib/containers/splitter_dock_container.dart
@@ -63,7 +63,7 @@ abstract class SplitterDockContainer implements IDockContainer {
 
   int get width {
     if (_cachedWidth == null) {
-      _cachedWidth = splitterPanel.panelElement.$dom_clientWidth;
+      _cachedWidth = splitterPanel.panelElement.clientWidth;
     }
     return _cachedWidth;
 //    return splitterPanel.panelElement.clientWidth;
@@ -71,7 +71,7 @@ abstract class SplitterDockContainer implements IDockContainer {
   
   int get height {
     if (_cachedHeight == null) {
-      _cachedHeight = splitterPanel.panelElement.$dom_clientHeight;
+      _cachedHeight = splitterPanel.panelElement.clientHeight;
     }
     return _cachedHeight; //splitterPanel.panelElement.clientHeight;
 //    return splitterPanel.panelElement.clientHeight;

--- a/lib/containers/splitter_dock_container.dart
+++ b/lib/containers/splitter_dock_container.dart
@@ -63,7 +63,7 @@ abstract class SplitterDockContainer implements IDockContainer {
 
   int get width {
     if (_cachedWidth == null) {
-      _cachedWidth = splitterPanel.panelElement.clientWidth;
+      _cachedWidth = splitterPanel.panelElement.$dom_clientWidth;
     }
     return _cachedWidth;
 //    return splitterPanel.panelElement.clientWidth;
@@ -71,7 +71,7 @@ abstract class SplitterDockContainer implements IDockContainer {
   
   int get height {
     if (_cachedHeight == null) {
-      _cachedHeight = splitterPanel.panelElement.clientHeight;
+      _cachedHeight = splitterPanel.panelElement.$dom_clientHeight;
     }
     return _cachedHeight; //splitterPanel.panelElement.clientHeight;
 //    return splitterPanel.panelElement.clientHeight;

--- a/lib/containers/splitter_dock_container.dart
+++ b/lib/containers/splitter_dock_container.dart
@@ -63,7 +63,7 @@ abstract class SplitterDockContainer implements IDockContainer {
 
   int get width {
     if (_cachedWidth == null) {
-      _cachedWidth = splitterPanel.panelElement.clientWidth;
+      _cachedWidth = splitterPanel.panelElement.client.width;
     }
     return _cachedWidth;
 //    return splitterPanel.panelElement.clientWidth;
@@ -71,7 +71,7 @@ abstract class SplitterDockContainer implements IDockContainer {
   
   int get height {
     if (_cachedHeight == null) {
-      _cachedHeight = splitterPanel.panelElement.clientHeight;
+      _cachedHeight = splitterPanel.panelElement.client.height;
     }
     return _cachedHeight; //splitterPanel.panelElement.clientHeight;
 //    return splitterPanel.panelElement.clientHeight;

--- a/lib/decorators/draggable_container.dart
+++ b/lib/decorators/draggable_container.dart
@@ -21,8 +21,8 @@ class DraggableContainer implements IDockContainer {
     containerType = delegate.containerType;
         
     mouseDownHandler = dragHandle.onMouseDown.listen(onMouseDown);
-    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.offset.left}";
+    topLevelElement.style.marginTop = "${topLevelElement.offset.top}";
   }
 
   void destroy() {

--- a/lib/decorators/draggable_container.dart
+++ b/lib/decorators/draggable_container.dart
@@ -21,8 +21,8 @@ class DraggableContainer implements IDockContainer {
     containerType = delegate.containerType;
         
     mouseDownHandler = dragHandle.onMouseDown.listen(onMouseDown);
-    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.$dom_offsetLeft}";
+    topLevelElement.style.marginTop = "${topLevelElement.$dom_offsetTop}";
   }
 
   void destroy() {
@@ -76,7 +76,7 @@ class DraggableContainer implements IDockContainer {
   
   void onMouseDown(MouseEvent event) {
     _startDragging(event);
-    previousMousePosition = new Point2(event.pageX, event.pageY);
+    previousMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
     if (mouseMoveHandler != null) {
       mouseMoveHandler.cancel();
       mouseMoveHandler = null;
@@ -114,7 +114,7 @@ class DraggableContainer implements IDockContainer {
   }
 
   void onMouseMove(MouseEvent event) {
-    Point2 currentMousePosition = new Point2(event.pageX, event.pageY);
+    Point2 currentMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
     int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
     int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
     _performDrag(dx, dy);

--- a/lib/decorators/draggable_container.dart
+++ b/lib/decorators/draggable_container.dart
@@ -76,7 +76,7 @@ class DraggableContainer implements IDockContainer {
   
   void onMouseDown(MouseEvent event) {
     _startDragging(event);
-    previousMousePosition = new Point2(event.pageX, event.pageY);
+    previousMousePosition = new Point2(event.page.x, event.page.y);
     if (mouseMoveHandler != null) {
       mouseMoveHandler.cancel();
       mouseMoveHandler = null;
@@ -114,7 +114,7 @@ class DraggableContainer implements IDockContainer {
   }
 
   void onMouseMove(MouseEvent event) {
-    Point2 currentMousePosition = new Point2(event.pageX, event.pageY);
+    Point2 currentMousePosition = new Point2(event.page.x, event.page.y);
     int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
     int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
     _performDrag(dx, dy);

--- a/lib/decorators/draggable_container.dart
+++ b/lib/decorators/draggable_container.dart
@@ -21,8 +21,8 @@ class DraggableContainer implements IDockContainer {
     containerType = delegate.containerType;
         
     mouseDownHandler = dragHandle.onMouseDown.listen(onMouseDown);
-    topLevelElement.style.marginLeft = "${topLevelElement.$dom_offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.$dom_offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
+    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
   }
 
   void destroy() {
@@ -76,7 +76,7 @@ class DraggableContainer implements IDockContainer {
   
   void onMouseDown(MouseEvent event) {
     _startDragging(event);
-    previousMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
+    previousMousePosition = new Point2(event.pageX, event.pageY);
     if (mouseMoveHandler != null) {
       mouseMoveHandler.cancel();
       mouseMoveHandler = null;
@@ -114,7 +114,7 @@ class DraggableContainer implements IDockContainer {
   }
 
   void onMouseMove(MouseEvent event) {
-    Point2 currentMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
+    Point2 currentMousePosition = new Point2(event.pageX, event.pageY);
     int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
     int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
     _performDrag(dx, dy);

--- a/lib/decorators/resizable_container.dart
+++ b/lib/decorators/resizable_container.dart
@@ -143,7 +143,7 @@ class ResizableContainer implements IDockContainer {
     
 //    window.requestLayoutFrame(() {
       dockManager.suspendLayout();
-      Point2 currentMousePosition = new Point2(e.pageX, e.pageY);
+      Point2 currentMousePosition = new Point2(e.page.x, e.page.y);
       int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
       int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
       _performDrag(handle, dx, dy);
@@ -154,7 +154,7 @@ class ResizableContainer implements IDockContainer {
   }
   
   void onMouseDown(ResizeHandle handle, MouseEvent event) {
-    previousMousePosition = new Point2(event.pageX, event.pageY);
+    previousMousePosition = new Point2(event.page.x, event.page.y);
     if (handle.mouseMoveHandlerSub != null) {
       handle.mouseMoveHandlerSub.cancel();
     }

--- a/lib/decorators/resizable_container.dart
+++ b/lib/decorators/resizable_container.dart
@@ -18,8 +18,8 @@ class ResizableContainer implements IDockContainer {
   
   ResizableContainer(this.dialog, this.delegate, this.topLevelElement) {
     containerType = delegate.containerType;
-    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.$dom_offsetLeft}";
+    topLevelElement.style.marginTop = "${topLevelElement.$dom_offsetTop}";
     _buildResizeHandles();
   }
   
@@ -143,7 +143,7 @@ class ResizableContainer implements IDockContainer {
     
 //    window.requestLayoutFrame(() {
       dockManager.suspendLayout();
-      Point2 currentMousePosition = new Point2(e.pageX, e.pageY);
+      Point2 currentMousePosition = new Point2(e.$dom_pageX, e.$dom_pageY);
       int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
       int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
       _performDrag(handle, dx, dy);
@@ -154,7 +154,7 @@ class ResizableContainer implements IDockContainer {
   }
   
   void onMouseDown(ResizeHandle handle, MouseEvent event) {
-    previousMousePosition = new Point2(event.pageX, event.pageY);
+    previousMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
     if (handle.mouseMoveHandlerSub != null) {
       handle.mouseMoveHandlerSub.cancel();
     }
@@ -181,8 +181,8 @@ class ResizableContainer implements IDockContainer {
     var bounds = new BoundingBox();
     bounds.left = getPixels(topLevelElement.style.marginLeft);
     bounds.top = getPixels(topLevelElement.style.marginTop);
-    bounds.width = topLevelElement.clientWidth;
-    bounds.height = topLevelElement.clientHeight;
+    bounds.width = topLevelElement.$dom_clientWidth;
+    bounds.height = topLevelElement.$dom_clientHeight;
     
     if (handle.east) _resizeEast(dx, bounds);
     if (handle.west) _resizeWest(dx, bounds);

--- a/lib/decorators/resizable_container.dart
+++ b/lib/decorators/resizable_container.dart
@@ -18,8 +18,8 @@ class ResizableContainer implements IDockContainer {
   
   ResizableContainer(this.dialog, this.delegate, this.topLevelElement) {
     containerType = delegate.containerType;
-    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.offset.left}";
+    topLevelElement.style.marginTop = "${topLevelElement.offset.top}";
     _buildResizeHandles();
   }
   
@@ -181,8 +181,8 @@ class ResizableContainer implements IDockContainer {
     var bounds = new BoundingBox();
     bounds.left = getPixels(topLevelElement.style.marginLeft);
     bounds.top = getPixels(topLevelElement.style.marginTop);
-    bounds.width = topLevelElement.clientWidth;
-    bounds.height = topLevelElement.clientHeight;
+    bounds.width = topLevelElement.client.width;
+    bounds.height = topLevelElement.client.height;
     
     if (handle.east) _resizeEast(dx, bounds);
     if (handle.west) _resizeWest(dx, bounds);

--- a/lib/decorators/resizable_container.dart
+++ b/lib/decorators/resizable_container.dart
@@ -18,8 +18,8 @@ class ResizableContainer implements IDockContainer {
   
   ResizableContainer(this.dialog, this.delegate, this.topLevelElement) {
     containerType = delegate.containerType;
-    topLevelElement.style.marginLeft = "${topLevelElement.$dom_offsetLeft}";
-    topLevelElement.style.marginTop = "${topLevelElement.$dom_offsetTop}";
+    topLevelElement.style.marginLeft = "${topLevelElement.offsetLeft}";
+    topLevelElement.style.marginTop = "${topLevelElement.offsetTop}";
     _buildResizeHandles();
   }
   
@@ -143,7 +143,7 @@ class ResizableContainer implements IDockContainer {
     
 //    window.requestLayoutFrame(() {
       dockManager.suspendLayout();
-      Point2 currentMousePosition = new Point2(e.$dom_pageX, e.$dom_pageY);
+      Point2 currentMousePosition = new Point2(e.pageX, e.pageY);
       int dx = (currentMousePosition.x - previousMousePosition.x).toInt();
       int dy = (currentMousePosition.y - previousMousePosition.y).toInt();
       _performDrag(handle, dx, dy);
@@ -154,7 +154,7 @@ class ResizableContainer implements IDockContainer {
   }
   
   void onMouseDown(ResizeHandle handle, MouseEvent event) {
-    previousMousePosition = new Point2(event.$dom_pageX, event.$dom_pageY);
+    previousMousePosition = new Point2(event.pageX, event.pageY);
     if (handle.mouseMoveHandlerSub != null) {
       handle.mouseMoveHandlerSub.cancel();
     }
@@ -181,8 +181,8 @@ class ResizableContainer implements IDockContainer {
     var bounds = new BoundingBox();
     bounds.left = getPixels(topLevelElement.style.marginLeft);
     bounds.top = getPixels(topLevelElement.style.marginTop);
-    bounds.width = topLevelElement.$dom_clientWidth;
-    bounds.height = topLevelElement.$dom_clientHeight;
+    bounds.width = topLevelElement.clientWidth;
+    bounds.height = topLevelElement.clientHeight;
     
     if (handle.east) _resizeEast(dx, bounds);
     if (handle.west) _resizeWest(dx, bounds);

--- a/lib/dialog/dialog.dart
+++ b/lib/dialog/dialog.dart
@@ -35,7 +35,7 @@ class Dialog {
     
     mouseDownHandler = elementDialog.onMouseDown.listen(onMouseDown);
     
-    resize(panel.elementPanel.$dom_clientWidth, panel.elementPanel.$dom_clientHeight);
+    resize(panel.elementPanel.clientWidth, panel.elementPanel.clientHeight);
     bringToFront();
   }
   

--- a/lib/dialog/dialog.dart
+++ b/lib/dialog/dialog.dart
@@ -35,7 +35,7 @@ class Dialog {
     
     mouseDownHandler = elementDialog.onMouseDown.listen(onMouseDown);
     
-    resize(panel.elementPanel.clientWidth, panel.elementPanel.clientHeight);
+    resize(panel.elementPanel.$dom_clientWidth, panel.elementPanel.$dom_clientHeight);
     bringToFront();
   }
   

--- a/lib/dialog/dialog.dart
+++ b/lib/dialog/dialog.dart
@@ -35,7 +35,7 @@ class Dialog {
     
     mouseDownHandler = elementDialog.onMouseDown.listen(onMouseDown);
     
-    resize(panel.elementPanel.clientWidth, panel.elementPanel.clientHeight);
+    resize(panel.elementPanel.client.width, panel.elementPanel.client.height);
     bringToFront();
   }
   

--- a/lib/dock/dock_layout_engine.dart
+++ b/lib/dock/dock_layout_engine.dart
@@ -116,12 +116,12 @@ class DockLayoutEngine {
       DockNode referenceParent = referenceNode.parent;
 
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeWidth = referenceNode.container.containerElement.clientWidth;
-      int referenceNodeHeight = referenceNode.container.containerElement.clientHeight;
+      int referenceNodeWidth = referenceNode.container.containerElement.$dom_clientWidth;
+      int referenceNodeHeight = referenceNode.container.containerElement.$dom_clientHeight;
       
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeParentWidth = referenceParent.container.containerElement.clientWidth;
-      int referenceNodeParentHeight = referenceParent.container.containerElement.clientHeight;
+      int referenceNodeParentWidth = referenceParent.container.containerElement.$dom_clientWidth;
+      int referenceNodeParentHeight = referenceParent.container.containerElement.$dom_clientHeight;
       
       // Replace the reference node with a new composite node with the reference and new node as it's children
       IDockContainer compositeContainer = _createDockContainer(direction, newNode, referenceNode);
@@ -159,14 +159,14 @@ class DockLayoutEngine {
     }
     
     // force resize the panel
-    int containerWidth = newNode.container.containerElement.clientWidth;
-    int containerHeight = newNode.container.containerElement.clientHeight;
+    int containerWidth = newNode.container.containerElement.$dom_clientWidth;
+    int containerHeight = newNode.container.containerElement.$dom_clientHeight;
     newNode.container.resize(containerWidth, containerHeight);
   }
   
   void _forceResizeCompositeContainer(IDockContainer container) {
-    int width = container.containerElement.clientWidth;
-    int height = container.containerElement.clientHeight;
+    int width = container.containerElement.$dom_clientWidth;
+    int height = container.containerElement.$dom_clientHeight;
     container.resize(width, height);
   }
   
@@ -200,10 +200,10 @@ class DockLayoutEngine {
       // TODO: Create a tab handle highlight to show that it's going to be docked in a tab
       Element targetElement = referenceNode.container.containerElement;
       Rectangle bounds = new Rectangle();
-      bounds.x = targetElement.offsetLeft;
-      bounds.y = targetElement.offsetTop;
-      bounds.width = targetElement.clientWidth;
-      bounds.height= targetElement.clientHeight;
+      bounds.x = targetElement.$dom_offsetLeft;
+      bounds.y = targetElement.$dom_offsetTop;
+      bounds.width = targetElement.$dom_clientWidth;
+      bounds.height= targetElement.$dom_clientHeight;
       return bounds;
     }
     
@@ -255,13 +255,13 @@ class DockLayoutEngine {
     
     Rectangle bounds = new Rectangle();
     if (direction == "vertical") {
-      bounds.x = compositeNode.container.containerElement.offsetLeft;
-      bounds.y = compositeNode.container.containerElement.offsetTop + targetPanelStart;
+      bounds.x = compositeNode.container.containerElement.$dom_offsetLeft;
+      bounds.y = compositeNode.container.containerElement.$dom_offsetTop + targetPanelStart;
       bounds.width = compositeNode.container.width; 
       bounds.height = targetPanelSize;
     } else if (direction == "horizontal") {
-      bounds.x = compositeNode.container.containerElement.offsetLeft + targetPanelStart;
-      bounds.y = compositeNode.container.containerElement.offsetTop;
+      bounds.x = compositeNode.container.containerElement.$dom_offsetLeft + targetPanelStart;
+      bounds.y = compositeNode.container.containerElement.$dom_offsetTop;
       bounds.width = targetPanelSize; 
       bounds.height = compositeNode.container.height;
     }

--- a/lib/dock/dock_layout_engine.dart
+++ b/lib/dock/dock_layout_engine.dart
@@ -116,12 +116,12 @@ class DockLayoutEngine {
       DockNode referenceParent = referenceNode.parent;
 
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeWidth = referenceNode.container.containerElement.$dom_clientWidth;
-      int referenceNodeHeight = referenceNode.container.containerElement.$dom_clientHeight;
+      int referenceNodeWidth = referenceNode.container.containerElement.clientWidth;
+      int referenceNodeHeight = referenceNode.container.containerElement.clientHeight;
       
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeParentWidth = referenceParent.container.containerElement.$dom_clientWidth;
-      int referenceNodeParentHeight = referenceParent.container.containerElement.$dom_clientHeight;
+      int referenceNodeParentWidth = referenceParent.container.containerElement.clientWidth;
+      int referenceNodeParentHeight = referenceParent.container.containerElement.clientHeight;
       
       // Replace the reference node with a new composite node with the reference and new node as it's children
       IDockContainer compositeContainer = _createDockContainer(direction, newNode, referenceNode);
@@ -159,14 +159,14 @@ class DockLayoutEngine {
     }
     
     // force resize the panel
-    int containerWidth = newNode.container.containerElement.$dom_clientWidth;
-    int containerHeight = newNode.container.containerElement.$dom_clientHeight;
+    int containerWidth = newNode.container.containerElement.clientWidth;
+    int containerHeight = newNode.container.containerElement.clientHeight;
     newNode.container.resize(containerWidth, containerHeight);
   }
   
   void _forceResizeCompositeContainer(IDockContainer container) {
-    int width = container.containerElement.$dom_clientWidth;
-    int height = container.containerElement.$dom_clientHeight;
+    int width = container.containerElement.clientWidth;
+    int height = container.containerElement.clientHeight;
     container.resize(width, height);
   }
   
@@ -200,10 +200,10 @@ class DockLayoutEngine {
       // TODO: Create a tab handle highlight to show that it's going to be docked in a tab
       Element targetElement = referenceNode.container.containerElement;
       Rectangle bounds = new Rectangle();
-      bounds.x = targetElement.$dom_offsetLeft;
-      bounds.y = targetElement.$dom_offsetTop;
-      bounds.width = targetElement.$dom_clientWidth;
-      bounds.height= targetElement.$dom_clientHeight;
+      bounds.x = targetElement.offsetLeft;
+      bounds.y = targetElement.offsetTop;
+      bounds.width = targetElement.clientWidth;
+      bounds.height= targetElement.clientHeight;
       return bounds;
     }
     
@@ -255,13 +255,13 @@ class DockLayoutEngine {
     
     Rectangle bounds = new Rectangle();
     if (direction == "vertical") {
-      bounds.x = compositeNode.container.containerElement.$dom_offsetLeft;
-      bounds.y = compositeNode.container.containerElement.$dom_offsetTop + targetPanelStart;
+      bounds.x = compositeNode.container.containerElement.offsetLeft;
+      bounds.y = compositeNode.container.containerElement.offsetTop + targetPanelStart;
       bounds.width = compositeNode.container.width; 
       bounds.height = targetPanelSize;
     } else if (direction == "horizontal") {
-      bounds.x = compositeNode.container.containerElement.$dom_offsetLeft + targetPanelStart;
-      bounds.y = compositeNode.container.containerElement.$dom_offsetTop;
+      bounds.x = compositeNode.container.containerElement.offsetLeft + targetPanelStart;
+      bounds.y = compositeNode.container.containerElement.offsetTop;
       bounds.width = targetPanelSize; 
       bounds.height = compositeNode.container.height;
     }

--- a/lib/dock/dock_layout_engine.dart
+++ b/lib/dock/dock_layout_engine.dart
@@ -116,12 +116,12 @@ class DockLayoutEngine {
       DockNode referenceParent = referenceNode.parent;
 
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeWidth = referenceNode.container.containerElement.clientWidth;
-      int referenceNodeHeight = referenceNode.container.containerElement.clientHeight;
+      int referenceNodeWidth = referenceNode.container.containerElement.client.width;
+      int referenceNodeHeight = referenceNode.container.containerElement.client.height;
       
       // Get the dimensions of the reference node, for resizing later on
-      int referenceNodeParentWidth = referenceParent.container.containerElement.clientWidth;
-      int referenceNodeParentHeight = referenceParent.container.containerElement.clientHeight;
+      int referenceNodeParentWidth = referenceParent.container.containerElement.client.width;
+      int referenceNodeParentHeight = referenceParent.container.containerElement.client.height;
       
       // Replace the reference node with a new composite node with the reference and new node as it's children
       IDockContainer compositeContainer = _createDockContainer(direction, newNode, referenceNode);
@@ -159,14 +159,14 @@ class DockLayoutEngine {
     }
     
     // force resize the panel
-    int containerWidth = newNode.container.containerElement.clientWidth;
-    int containerHeight = newNode.container.containerElement.clientHeight;
+    int containerWidth = newNode.container.containerElement.client.width;
+    int containerHeight = newNode.container.containerElement.client.height;
     newNode.container.resize(containerWidth, containerHeight);
   }
   
   void _forceResizeCompositeContainer(IDockContainer container) {
-    int width = container.containerElement.clientWidth;
-    int height = container.containerElement.clientHeight;
+    int width = container.containerElement.client.width;
+    int height = container.containerElement.client.height;
     container.resize(width, height);
   }
   
@@ -200,10 +200,10 @@ class DockLayoutEngine {
       // TODO: Create a tab handle highlight to show that it's going to be docked in a tab
       Element targetElement = referenceNode.container.containerElement;
       Rectangle bounds = new Rectangle();
-      bounds.x = targetElement.offsetLeft;
-      bounds.y = targetElement.offsetTop;
-      bounds.width = targetElement.clientWidth;
-      bounds.height= targetElement.clientHeight;
+      bounds.x = targetElement.offset.left;
+      bounds.y = targetElement.offset.top;
+      bounds.width = targetElement.client.width;
+      bounds.height= targetElement.client.height;
       return bounds;
     }
     
@@ -255,13 +255,13 @@ class DockLayoutEngine {
     
     Rectangle bounds = new Rectangle();
     if (direction == "vertical") {
-      bounds.x = compositeNode.container.containerElement.offsetLeft;
-      bounds.y = compositeNode.container.containerElement.offsetTop + targetPanelStart;
+      bounds.x = compositeNode.container.containerElement.offset.left;
+      bounds.y = compositeNode.container.containerElement.offset.top + targetPanelStart;
       bounds.width = compositeNode.container.width; 
       bounds.height = targetPanelSize;
     } else if (direction == "horizontal") {
-      bounds.x = compositeNode.container.containerElement.offsetLeft + targetPanelStart;
-      bounds.y = compositeNode.container.containerElement.offsetTop;
+      bounds.x = compositeNode.container.containerElement.offset.left + targetPanelStart;
+      bounds.y = compositeNode.container.containerElement.offset.top;
       bounds.width = targetPanelSize; 
       bounds.height = compositeNode.container.height;
     }

--- a/lib/dock/dock_manager.dart
+++ b/lib/dock/dock_manager.dart
@@ -27,7 +27,7 @@ class DockManager implements DialogEventListener {
     context.model.documentManagerNode = documentNode;
     setRootNode(context.model.rootNode);
     // Resize the layout
-    resize(element.clientWidth, element.clientHeight);
+    resize(element.$dom_clientWidth, element.$dom_clientHeight);
     dockWheel = new DockWheel(this);
     layoutEngine = new DockLayoutEngine(this);
     
@@ -40,7 +40,7 @@ class DockManager implements DialogEventListener {
   }
   
   void invalidate() {
-    resize(element.clientWidth, element.clientHeight);
+    resize(element.$dom_clientWidth, element.$dom_clientHeight);
   }
   
   void resize(int width, int height) {
@@ -75,7 +75,7 @@ class DockManager implements DialogEventListener {
   
 
   void onDialogDragStarted(Dialog sender, MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.$dom_pageX, e.$dom_pageY);
     dockWheel.activeDialog = sender;
     dockWheel.showWheel();
     if (mouseMoveHandler != null) {
@@ -95,7 +95,7 @@ class DockManager implements DialogEventListener {
   }
   
   void onMouseMoved(MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.$dom_pageX, e.$dom_pageY);
   }
   
   /**
@@ -218,13 +218,13 @@ class DockManager implements DialogEventListener {
     var dialog = new Dialog(node.container, this);
 
     // Adjust the relative position
-    num dialogWidth = dialog.elementDialog.clientWidth;
+    num dialogWidth = dialog.elementDialog.$dom_clientWidth;
     if (dragOffset.x > dialogWidth) {
       dragOffset.x = 0.75 * dialogWidth;
     }
     dialog.setPosition(
-        event.pageX - dragOffset.x, 
-        event.pageY - dragOffset.y);
+        event.$dom_pageX - dragOffset.x, 
+        event.$dom_pageY - dragOffset.y);
     dialog.draggable.onMouseDown(event);
 
     return dialog;

--- a/lib/dock/dock_manager.dart
+++ b/lib/dock/dock_manager.dart
@@ -75,7 +75,7 @@ class DockManager implements DialogEventListener {
   
 
   void onDialogDragStarted(Dialog sender, MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.page.x, e.page.y);
     dockWheel.activeDialog = sender;
     dockWheel.showWheel();
     if (mouseMoveHandler != null) {
@@ -95,7 +95,7 @@ class DockManager implements DialogEventListener {
   }
   
   void onMouseMoved(MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.page.x, e.page.y);
   }
   
   /**
@@ -223,8 +223,8 @@ class DockManager implements DialogEventListener {
       dragOffset.x = 0.75 * dialogWidth;
     }
     dialog.setPosition(
-        event.pageX - dragOffset.x, 
-        event.pageY - dragOffset.y);
+        event.page.x - dragOffset.x, 
+        event.page.y - dragOffset.y);
     dialog.draggable.onMouseDown(event);
 
     return dialog;

--- a/lib/dock/dock_manager.dart
+++ b/lib/dock/dock_manager.dart
@@ -27,7 +27,7 @@ class DockManager implements DialogEventListener {
     context.model.documentManagerNode = documentNode;
     setRootNode(context.model.rootNode);
     // Resize the layout
-    resize(element.clientWidth, element.clientHeight);
+    resize(element.client.width, element.client.height);
     dockWheel = new DockWheel(this);
     layoutEngine = new DockLayoutEngine(this);
     
@@ -40,7 +40,7 @@ class DockManager implements DialogEventListener {
   }
   
   void invalidate() {
-    resize(element.clientWidth, element.clientHeight);
+    resize(element.client.width, element.client.height);
   }
   
   void resize(int width, int height) {
@@ -218,7 +218,7 @@ class DockManager implements DialogEventListener {
     var dialog = new Dialog(node.container, this);
 
     // Adjust the relative position
-    num dialogWidth = dialog.elementDialog.clientWidth;
+    num dialogWidth = dialog.elementDialog.client.width;
     if (dragOffset.x > dialogWidth) {
       dragOffset.x = 0.75 * dialogWidth;
     }

--- a/lib/dock/dock_manager.dart
+++ b/lib/dock/dock_manager.dart
@@ -27,7 +27,7 @@ class DockManager implements DialogEventListener {
     context.model.documentManagerNode = documentNode;
     setRootNode(context.model.rootNode);
     // Resize the layout
-    resize(element.$dom_clientWidth, element.$dom_clientHeight);
+    resize(element.clientWidth, element.clientHeight);
     dockWheel = new DockWheel(this);
     layoutEngine = new DockLayoutEngine(this);
     
@@ -40,7 +40,7 @@ class DockManager implements DialogEventListener {
   }
   
   void invalidate() {
-    resize(element.$dom_clientWidth, element.$dom_clientHeight);
+    resize(element.clientWidth, element.clientHeight);
   }
   
   void resize(int width, int height) {
@@ -75,7 +75,7 @@ class DockManager implements DialogEventListener {
   
 
   void onDialogDragStarted(Dialog sender, MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.$dom_pageX, e.$dom_pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
     dockWheel.activeDialog = sender;
     dockWheel.showWheel();
     if (mouseMoveHandler != null) {
@@ -95,7 +95,7 @@ class DockManager implements DialogEventListener {
   }
   
   void onMouseMoved(MouseEvent e) {
-    dockWheel.activeNode = _findNodeOnPoint(e.$dom_pageX, e.$dom_pageY);
+    dockWheel.activeNode = _findNodeOnPoint(e.pageX, e.pageY);
   }
   
   /**
@@ -218,13 +218,13 @@ class DockManager implements DialogEventListener {
     var dialog = new Dialog(node.container, this);
 
     // Adjust the relative position
-    num dialogWidth = dialog.elementDialog.$dom_clientWidth;
+    num dialogWidth = dialog.elementDialog.clientWidth;
     if (dragOffset.x > dialogWidth) {
       dragOffset.x = 0.75 * dialogWidth;
     }
     dialog.setPosition(
-        event.$dom_pageX - dragOffset.x, 
-        event.$dom_pageY - dragOffset.y);
+        event.pageX - dragOffset.x, 
+        event.pageY - dragOffset.y);
     dialog.draggable.onMouseDown(event);
 
     return dialog;

--- a/lib/dock/dock_model.dart
+++ b/lib/dock/dock_model.dart
@@ -59,8 +59,8 @@ class DockNode {
     childNode.parent = this;
     
     int referenceIndex = children.indexOf(referenceNode);
-    List<DockNode> preList = children.getRange(0, referenceIndex);
-    List<DockNode> postList = children.getRange(referenceIndex + 1, children.length - (referenceIndex + 1));
+    List<DockNode> preList = children.sublist(0, referenceIndex);
+    List<DockNode> postList = children.sublist(referenceIndex + 1, children.length);
     
     children = new List<DockNode>();
     children.addAll(preList);

--- a/lib/dock/dock_wheel.dart
+++ b/lib/dock/dock_wheel.dart
@@ -69,20 +69,20 @@ class DockWheel {
       return;
     }
     Element element = activeNode.container.containerElement;
-    int containerWidth = element.clientWidth;
-    int containerHeight = element.clientHeight;
-    int baseX = containerWidth ~/ 2 + element.offsetLeft;
-    int baseY = containerHeight ~/ 2 + element.offsetTop;
+    int containerWidth = element.$dom_clientWidth;
+    int containerHeight = element.$dom_clientHeight;
+    int baseX = containerWidth ~/ 2 + element.$dom_offsetLeft;
+    int baseY = containerHeight ~/ 2 + element.$dom_offsetTop;
     elementMainWheel.style.left = "${baseX}px";
     elementMainWheel.style.top = "${baseY}px";
     
     // The positioning of the main dock wheel buttons is done automatically through CSS
     // Dynamically calculate the positions of the buttons on the extreme sides of the dock manager
     num sideMargin = 20;
-    num dockManagerWidth = dockManager.element.clientWidth;
-    num dockManagerHeight = dockManager.element.clientHeight;
-    num dockManagerOffsetX = dockManager.element.offsetLeft;
-    num dockManagerOffsetY = dockManager.element.offsetTop;
+    num dockManagerWidth = dockManager.element.$dom_clientWidth;
+    num dockManagerHeight = dockManager.element.$dom_clientHeight;
+    num dockManagerOffsetX = dockManager.element.$dom_offsetLeft;
+    num dockManagerOffsetY = dockManager.element.$dom_offsetTop;
 
     elementMainWheel.remove();
     elementSideWheel.remove();
@@ -98,8 +98,8 @@ class DockWheel {
   
   void _setWheelButtonPosition(String wheelId, num left, num top) {
     DockWheelItem item = wheelItems[wheelId];
-    num itemHalfWidth = item.element.clientWidth / 2;
-    num itemHalfHeight = item.element.clientHeight / 2;
+    num itemHalfWidth = item.element.$dom_clientWidth / 2;
+    num itemHalfHeight = item.element.$dom_clientHeight / 2;
     
     int x = (left - itemHalfWidth).toInt();
     int y = (top - itemHalfHeight).toInt();

--- a/lib/dock/dock_wheel.dart
+++ b/lib/dock/dock_wheel.dart
@@ -69,20 +69,20 @@ class DockWheel {
       return;
     }
     Element element = activeNode.container.containerElement;
-    int containerWidth = element.$dom_clientWidth;
-    int containerHeight = element.$dom_clientHeight;
-    int baseX = containerWidth ~/ 2 + element.$dom_offsetLeft;
-    int baseY = containerHeight ~/ 2 + element.$dom_offsetTop;
+    int containerWidth = element.clientWidth;
+    int containerHeight = element.clientHeight;
+    int baseX = containerWidth ~/ 2 + element.offsetLeft;
+    int baseY = containerHeight ~/ 2 + element.offsetTop;
     elementMainWheel.style.left = "${baseX}px";
     elementMainWheel.style.top = "${baseY}px";
     
     // The positioning of the main dock wheel buttons is done automatically through CSS
     // Dynamically calculate the positions of the buttons on the extreme sides of the dock manager
     num sideMargin = 20;
-    num dockManagerWidth = dockManager.element.$dom_clientWidth;
-    num dockManagerHeight = dockManager.element.$dom_clientHeight;
-    num dockManagerOffsetX = dockManager.element.$dom_offsetLeft;
-    num dockManagerOffsetY = dockManager.element.$dom_offsetTop;
+    num dockManagerWidth = dockManager.element.clientWidth;
+    num dockManagerHeight = dockManager.element.clientHeight;
+    num dockManagerOffsetX = dockManager.element.offsetLeft;
+    num dockManagerOffsetY = dockManager.element.offsetTop;
 
     elementMainWheel.remove();
     elementSideWheel.remove();
@@ -98,8 +98,8 @@ class DockWheel {
   
   void _setWheelButtonPosition(String wheelId, num left, num top) {
     DockWheelItem item = wheelItems[wheelId];
-    num itemHalfWidth = item.element.$dom_clientWidth / 2;
-    num itemHalfHeight = item.element.$dom_clientHeight / 2;
+    num itemHalfWidth = item.element.clientWidth / 2;
+    num itemHalfHeight = item.element.clientHeight / 2;
     
     int x = (left - itemHalfWidth).toInt();
     int y = (top - itemHalfHeight).toInt();

--- a/lib/dock/dock_wheel.dart
+++ b/lib/dock/dock_wheel.dart
@@ -69,20 +69,20 @@ class DockWheel {
       return;
     }
     Element element = activeNode.container.containerElement;
-    int containerWidth = element.clientWidth;
-    int containerHeight = element.clientHeight;
-    int baseX = containerWidth ~/ 2 + element.offsetLeft;
-    int baseY = containerHeight ~/ 2 + element.offsetTop;
+    int containerWidth = element.client.width;
+    int containerHeight = element.client.height;
+    int baseX = containerWidth ~/ 2 + element.offset.left;
+    int baseY = containerHeight ~/ 2 + element.offset.top;
     elementMainWheel.style.left = "${baseX}px";
     elementMainWheel.style.top = "${baseY}px";
     
     // The positioning of the main dock wheel buttons is done automatically through CSS
     // Dynamically calculate the positions of the buttons on the extreme sides of the dock manager
     num sideMargin = 20;
-    num dockManagerWidth = dockManager.element.clientWidth;
-    num dockManagerHeight = dockManager.element.clientHeight;
-    num dockManagerOffsetX = dockManager.element.offsetLeft;
-    num dockManagerOffsetY = dockManager.element.offsetTop;
+    num dockManagerWidth = dockManager.element.client.width;
+    num dockManagerHeight = dockManager.element.client.height;
+    num dockManagerOffsetX = dockManager.element.offset.left;
+    num dockManagerOffsetY = dockManager.element.offset.top;
 
     elementMainWheel.remove();
     elementSideWheel.remove();
@@ -98,8 +98,8 @@ class DockWheel {
   
   void _setWheelButtonPosition(String wheelId, num left, num top) {
     DockWheelItem item = wheelItems[wheelId];
-    num itemHalfWidth = item.element.clientWidth / 2;
-    num itemHalfHeight = item.element.clientHeight / 2;
+    num itemHalfWidth = item.element.client.width / 2;
+    num itemHalfHeight = item.element.client.height / 2;
     
     int x = (left - itemHalfWidth).toInt();
     int y = (top - itemHalfHeight).toInt();

--- a/lib/splitter/splitter_bar.dart
+++ b/lib/splitter/splitter_bar.dart
@@ -37,8 +37,8 @@ class SplitterBar {
     readyToProcessNextDrag = false;
     var dockManager = previousContainer.dockManager;
     dockManager.suspendLayout();
-    int dx = e.pageX - previousMouseEvent.pageX;
-    int dy = e.pageY - previousMouseEvent.pageY;
+    int dx = e.$dom_pageX - previousMouseEvent.$dom_pageX;
+    int dy = e.$dom_pageY - previousMouseEvent.$dom_pageY;
     _performDrag(dx, dy);
     previousMouseEvent = e;
     readyToProcessNextDrag = true;
@@ -46,10 +46,10 @@ class SplitterBar {
   }
   
   void _performDrag(int dx, int dy) {
-    int previousWidth = previousContainer.containerElement.clientWidth;
-    int previousHeight = previousContainer.containerElement.clientHeight;
-    int nextWidth = nextContainer.containerElement.clientWidth;
-    int nextHeight = nextContainer.containerElement.clientHeight;
+    int previousWidth = previousContainer.containerElement.$dom_clientWidth;
+    int previousHeight = previousContainer.containerElement.$dom_clientHeight;
+    int nextWidth = nextContainer.containerElement.$dom_clientWidth;
+    int nextHeight = nextContainer.containerElement.$dom_clientHeight;
     
     int previousPanelSize = stackedVertical ? previousHeight : previousWidth; 
     int nextPanelSize = stackedVertical ? nextHeight : nextWidth;

--- a/lib/splitter/splitter_bar.dart
+++ b/lib/splitter/splitter_bar.dart
@@ -37,8 +37,8 @@ class SplitterBar {
     readyToProcessNextDrag = false;
     var dockManager = previousContainer.dockManager;
     dockManager.suspendLayout();
-    int dx = e.pageX - previousMouseEvent.pageX;
-    int dy = e.pageY - previousMouseEvent.pageY;
+    int dx = e.page.x - previousMouseEvent.page.x;
+    int dy = e.page.y - previousMouseEvent.page.y;
     _performDrag(dx, dy);
     previousMouseEvent = e;
     readyToProcessNextDrag = true;

--- a/lib/splitter/splitter_bar.dart
+++ b/lib/splitter/splitter_bar.dart
@@ -46,10 +46,10 @@ class SplitterBar {
   }
   
   void _performDrag(int dx, int dy) {
-    int previousWidth = previousContainer.containerElement.clientWidth;
-    int previousHeight = previousContainer.containerElement.clientHeight;
-    int nextWidth = nextContainer.containerElement.clientWidth;
-    int nextHeight = nextContainer.containerElement.clientHeight;
+    int previousWidth = previousContainer.containerElement.client.width;
+    int previousHeight = previousContainer.containerElement.client.height;
+    int nextWidth = nextContainer.containerElement.client.width;
+    int nextHeight = nextContainer.containerElement.client.height;
     
     int previousPanelSize = stackedVertical ? previousHeight : previousWidth; 
     int nextPanelSize = stackedVertical ? nextHeight : nextWidth;

--- a/lib/splitter/splitter_bar.dart
+++ b/lib/splitter/splitter_bar.dart
@@ -37,8 +37,8 @@ class SplitterBar {
     readyToProcessNextDrag = false;
     var dockManager = previousContainer.dockManager;
     dockManager.suspendLayout();
-    int dx = e.$dom_pageX - previousMouseEvent.$dom_pageX;
-    int dy = e.$dom_pageY - previousMouseEvent.$dom_pageY;
+    int dx = e.pageX - previousMouseEvent.pageX;
+    int dy = e.pageY - previousMouseEvent.pageY;
     _performDrag(dx, dy);
     previousMouseEvent = e;
     readyToProcessNextDrag = true;
@@ -46,10 +46,10 @@ class SplitterBar {
   }
   
   void _performDrag(int dx, int dy) {
-    int previousWidth = previousContainer.containerElement.$dom_clientWidth;
-    int previousHeight = previousContainer.containerElement.$dom_clientHeight;
-    int nextWidth = nextContainer.containerElement.$dom_clientWidth;
-    int nextHeight = nextContainer.containerElement.$dom_clientHeight;
+    int previousWidth = previousContainer.containerElement.clientWidth;
+    int previousHeight = previousContainer.containerElement.clientHeight;
+    int nextWidth = nextContainer.containerElement.clientWidth;
+    int nextHeight = nextContainer.containerElement.clientHeight;
     
     int previousPanelSize = stackedVertical ? previousHeight : previousWidth; 
     int nextPanelSize = stackedVertical ? nextHeight : nextWidth;

--- a/lib/splitter/splitter_panel.dart
+++ b/lib/splitter/splitter_panel.dart
@@ -71,9 +71,9 @@ class SplitterPanel {
    * The percentage is specified in [ratio] and is between 0..1
    */ 
   void setContainerRatio(IDockContainer container, num ratio) {
-    num splitPanelSize = stackedVertical ? panelElement.clientHeight : panelElement.clientWidth;
+    num splitPanelSize = stackedVertical ? panelElement.client.height : panelElement.client.width;
     num newContainerSize = splitPanelSize * ratio;
-    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.client.height : spiltterBars[0].barElement.client.width;
 
     num otherPanelSizeQuota = splitPanelSize - newContainerSize - barSize * spiltterBars.length;
     num otherPanelScaleMultipler = otherPanelSizeQuota / splitPanelSize;
@@ -81,7 +81,7 @@ class SplitterPanel {
     childContainers.forEach((child) {
       num size;
       if (child != container) {
-        size = stackedVertical ? child.containerElement.clientHeight : child.containerElement.clientWidth;
+        size = stackedVertical ? child.containerElement.client.height : child.containerElement.client.width;
         size *=  otherPanelScaleMultipler;
       } else {
         size = newContainerSize;
@@ -129,7 +129,7 @@ class SplitterPanel {
     });
     
     // Get the thickness of the bar
-    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.client.height : spiltterBars[0].barElement.client.width;
     
     // Find out how much space existing child containers will take after being resized (excluding the splitter bars)  
     int targetTotalChildPanelSize = stackedVertical ? height : width;
@@ -144,8 +144,8 @@ class SplitterPanel {
     for (int i = 0; i < childContainers.length; i++) {
       var child = childContainers[i];
       int original = stackedVertical ? 
-          child.containerElement.clientHeight : 
-          child.containerElement.clientWidth;
+          child.containerElement.client.height : 
+          child.containerElement.client.width;
 
       int newSize = (original * scaleMultiplier).toInt();
       updatedTotalChildPanelSize += newSize;

--- a/lib/splitter/splitter_panel.dart
+++ b/lib/splitter/splitter_panel.dart
@@ -71,9 +71,9 @@ class SplitterPanel {
    * The percentage is specified in [ratio] and is between 0..1
    */ 
   void setContainerRatio(IDockContainer container, num ratio) {
-    num splitPanelSize = stackedVertical ? panelElement.$dom_clientHeight : panelElement.$dom_clientWidth;
+    num splitPanelSize = stackedVertical ? panelElement.clientHeight : panelElement.clientWidth;
     num newContainerSize = splitPanelSize * ratio;
-    int barSize = stackedVertical ? spiltterBars[0].barElement.$dom_clientHeight : spiltterBars[0].barElement.$dom_clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
 
     num otherPanelSizeQuota = splitPanelSize - newContainerSize - barSize * spiltterBars.length;
     num otherPanelScaleMultipler = otherPanelSizeQuota / splitPanelSize;
@@ -81,7 +81,7 @@ class SplitterPanel {
     childContainers.forEach((child) {
       num size;
       if (child != container) {
-        size = stackedVertical ? child.containerElement.$dom_clientHeight : child.containerElement.$dom_clientWidth;
+        size = stackedVertical ? child.containerElement.clientHeight : child.containerElement.clientWidth;
         size *=  otherPanelScaleMultipler;
       } else {
         size = newContainerSize;
@@ -129,7 +129,7 @@ class SplitterPanel {
     });
     
     // Get the thickness of the bar
-    int barSize = stackedVertical ? spiltterBars[0].barElement.$dom_clientHeight : spiltterBars[0].barElement.$dom_clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
     
     // Find out how much space existing child containers will take after being resized (excluding the splitter bars)  
     int targetTotalChildPanelSize = stackedVertical ? height : width;
@@ -144,8 +144,8 @@ class SplitterPanel {
     for (int i = 0; i < childContainers.length; i++) {
       var child = childContainers[i];
       int original = stackedVertical ? 
-          child.containerElement.$dom_clientHeight : 
-          child.containerElement.$dom_clientWidth;
+          child.containerElement.clientHeight : 
+          child.containerElement.clientWidth;
 
       int newSize = (original * scaleMultiplier).toInt();
       updatedTotalChildPanelSize += newSize;

--- a/lib/splitter/splitter_panel.dart
+++ b/lib/splitter/splitter_panel.dart
@@ -71,9 +71,9 @@ class SplitterPanel {
    * The percentage is specified in [ratio] and is between 0..1
    */ 
   void setContainerRatio(IDockContainer container, num ratio) {
-    num splitPanelSize = stackedVertical ? panelElement.clientHeight : panelElement.clientWidth;
+    num splitPanelSize = stackedVertical ? panelElement.$dom_clientHeight : panelElement.$dom_clientWidth;
     num newContainerSize = splitPanelSize * ratio;
-    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.$dom_clientHeight : spiltterBars[0].barElement.$dom_clientWidth;
 
     num otherPanelSizeQuota = splitPanelSize - newContainerSize - barSize * spiltterBars.length;
     num otherPanelScaleMultipler = otherPanelSizeQuota / splitPanelSize;
@@ -81,7 +81,7 @@ class SplitterPanel {
     childContainers.forEach((child) {
       num size;
       if (child != container) {
-        size = stackedVertical ? child.containerElement.clientHeight : child.containerElement.clientWidth;
+        size = stackedVertical ? child.containerElement.$dom_clientHeight : child.containerElement.$dom_clientWidth;
         size *=  otherPanelScaleMultipler;
       } else {
         size = newContainerSize;
@@ -129,7 +129,7 @@ class SplitterPanel {
     });
     
     // Get the thickness of the bar
-    int barSize = stackedVertical ? spiltterBars[0].barElement.clientHeight : spiltterBars[0].barElement.clientWidth;
+    int barSize = stackedVertical ? spiltterBars[0].barElement.$dom_clientHeight : spiltterBars[0].barElement.$dom_clientWidth;
     
     // Find out how much space existing child containers will take after being resized (excluding the splitter bars)  
     int targetTotalChildPanelSize = stackedVertical ? height : width;
@@ -144,8 +144,8 @@ class SplitterPanel {
     for (int i = 0; i < childContainers.length; i++) {
       var child = childContainers[i];
       int original = stackedVertical ? 
-          child.containerElement.clientHeight : 
-          child.containerElement.clientWidth;
+          child.containerElement.$dom_clientHeight : 
+          child.containerElement.$dom_clientWidth;
 
       int newSize = (original * scaleMultiplier).toInt();
       updatedTotalChildPanelSize += newSize;

--- a/lib/tab/tab_host.dart
+++ b/lib/tab/tab_host.dart
@@ -72,8 +72,8 @@ class TabHost {
     hostElement.style.width = "${width}px";
     hostElement.style.height = "${height}px";
     
-    int tabHeight = tabListElement.clientHeight;
-    int separatorHeight = separatorElement.clientHeight;
+    int tabHeight = tabListElement.$dom_clientHeight;
+    int separatorHeight = separatorElement.$dom_clientHeight;
     int contentHeight = height - tabHeight - separatorHeight;
     contentElement.style.height = "${contentHeight}px";
     

--- a/lib/tab/tab_host.dart
+++ b/lib/tab/tab_host.dart
@@ -72,8 +72,8 @@ class TabHost {
     hostElement.style.width = "${width}px";
     hostElement.style.height = "${height}px";
     
-    int tabHeight = tabListElement.$dom_clientHeight;
-    int separatorHeight = separatorElement.$dom_clientHeight;
+    int tabHeight = tabListElement.clientHeight;
+    int separatorHeight = separatorElement.clientHeight;
     int contentHeight = height - tabHeight - separatorHeight;
     contentElement.style.height = "${contentHeight}px";
     

--- a/lib/tab/tab_host.dart
+++ b/lib/tab/tab_host.dart
@@ -72,8 +72,8 @@ class TabHost {
     hostElement.style.width = "${width}px";
     hostElement.style.height = "${height}px";
     
-    int tabHeight = tabListElement.clientHeight;
-    int separatorHeight = separatorElement.clientHeight;
+    int tabHeight = tabListElement.client.height;
+    int separatorHeight = separatorElement.client.height;
     int contentHeight = height - tabHeight - separatorHeight;
     contentElement.style.height = "${contentHeight}px";
     

--- a/lib/tab/tab_page.dart
+++ b/lib/tab/tab_page.dart
@@ -42,8 +42,8 @@ class TabPage {
     if (selected) {
       host.contentElement.nodes.add(containerElement);
       // force a resize again
-      int width = host.contentElement.$dom_clientWidth;
-      int height = host.contentElement.$dom_clientHeight;
+      int width = host.contentElement.clientWidth;
+      int height = host.contentElement.clientHeight;
       container.resize(width, height);
     } else {
       containerElement.remove();

--- a/lib/tab/tab_page.dart
+++ b/lib/tab/tab_page.dart
@@ -42,8 +42,8 @@ class TabPage {
     if (selected) {
       host.contentElement.nodes.add(containerElement);
       // force a resize again
-      int width = host.contentElement.clientWidth;
-      int height = host.contentElement.clientHeight;
+      int width = host.contentElement.$dom_clientWidth;
+      int height = host.contentElement.$dom_clientHeight;
       container.resize(width, height);
     } else {
       containerElement.remove();

--- a/lib/tab/tab_page.dart
+++ b/lib/tab/tab_page.dart
@@ -42,8 +42,8 @@ class TabPage {
     if (selected) {
       host.contentElement.nodes.add(containerElement);
       // force a resize again
-      int width = host.contentElement.clientWidth;
-      int height = host.contentElement.clientHeight;
+      int width = host.contentElement.client.width;
+      int height = host.contentElement.client.height;
       container.resize(width, height);
     } else {
       containerElement.remove();

--- a/lib/utils/dock_utils.dart
+++ b/lib/utils/dock_utils.dart
@@ -7,12 +7,12 @@ int getPixels(String pixels) {
 
 
 Point2 getMousePosition(MouseEvent e, Element element) {
-  int parentOffsetX = element.offsetLeft;
-  int parentOffsetY = element.offsetTop;
-  int parentWidth = element.clientWidth;
-  int parentHeight = element.clientHeight;
-  int x = e.offsetX - parentOffsetX;
-  int y = e.offsetX - parentOffsetY;
+  int parentOffsetX = element.$dom_offsetLeft;
+  int parentOffsetY = element.$dom_offsetTop;
+  int parentWidth = element.$dom_clientWidth;
+  int parentHeight = element.$dom_clientHeight;
+  int x = e.$dom_offsetX - parentOffsetX;
+  int y = e.$dom_offsetX - parentOffsetY;
   return new Point2(x, y);
 }
 
@@ -26,10 +26,10 @@ void enableGlobalTextSelection() {
 
 bool isPointInsideNode(int px, int py, DockNode node) {
   Element element = node.container.containerElement;
-  int x = element.offsetLeft;
-  int y = element.offsetTop;
-  int width = element.clientWidth;
-  int height = element.clientHeight;
+  int x = element.$dom_offsetLeft;
+  int y = element.$dom_offsetTop;
+  int width = element.$dom_clientWidth;
+  int height = element.$dom_clientHeight;
   
   return (px >= x && px <= x + width && py >= y && py <= y + height);
 }

--- a/lib/utils/dock_utils.dart
+++ b/lib/utils/dock_utils.dart
@@ -7,12 +7,12 @@ int getPixels(String pixels) {
 
 
 Point2 getMousePosition(MouseEvent e, Element element) {
-  int parentOffsetX = element.offsetLeft;
-  int parentOffsetY = element.offsetTop;
-  int parentWidth = element.clientWidth;
-  int parentHeight = element.clientHeight;
-  int x = e.offsetX - parentOffsetX;
-  int y = e.offsetX - parentOffsetY;
+  int parentOffsetX = element.offset.left;
+  int parentOffsetY = element.offset.top;
+  int parentWidth = element.client.width;
+  int parentHeight = element.client.height;
+  int x = e.offset.x - parentOffsetX;
+  int y = e.offset.x - parentOffsetY;
   return new Point2(x, y);
 }
 
@@ -26,10 +26,10 @@ void enableGlobalTextSelection() {
 
 bool isPointInsideNode(int px, int py, DockNode node) {
   Element element = node.container.containerElement;
-  int x = element.offsetLeft;
-  int y = element.offsetTop;
-  int width = element.clientWidth;
-  int height = element.clientHeight;
+  int x = element.offset.left;
+  int y = element.offset.top;
+  int width = element.client.width;
+  int height = element.client.height;
   
   return (px >= x && px <= x + width && py >= y && py <= y + height);
 }

--- a/lib/utils/dock_utils.dart
+++ b/lib/utils/dock_utils.dart
@@ -7,12 +7,12 @@ int getPixels(String pixels) {
 
 
 Point2 getMousePosition(MouseEvent e, Element element) {
-  int parentOffsetX = element.$dom_offsetLeft;
-  int parentOffsetY = element.$dom_offsetTop;
-  int parentWidth = element.$dom_clientWidth;
-  int parentHeight = element.$dom_clientHeight;
-  int x = e.$dom_offsetX - parentOffsetX;
-  int y = e.$dom_offsetX - parentOffsetY;
+  int parentOffsetX = element.offsetLeft;
+  int parentOffsetY = element.offsetTop;
+  int parentWidth = element.clientWidth;
+  int parentHeight = element.clientHeight;
+  int x = e.offsetX - parentOffsetX;
+  int y = e.offsetX - parentOffsetY;
   return new Point2(x, y);
 }
 
@@ -26,10 +26,10 @@ void enableGlobalTextSelection() {
 
 bool isPointInsideNode(int px, int py, DockNode node) {
   Element element = node.container.containerElement;
-  int x = element.$dom_offsetLeft;
-  int y = element.$dom_offsetTop;
-  int width = element.$dom_clientWidth;
-  int height = element.$dom_clientHeight;
+  int x = element.offsetLeft;
+  int y = element.offsetTop;
+  int width = element.clientWidth;
+  int height = element.clientHeight;
   
   return (px >= x && px <= x + width && py >= y && py <= y + height);
 }

--- a/lib/utils/undock_initiator.dart
+++ b/lib/utils/undock_initiator.dart
@@ -55,7 +55,7 @@ class UndockInitiator {
       _cancelSubscription(mouseMoveHandler);
       mouseUpHandler = window.onMouseUp.listen(onMouseUp);
       mouseMoveHandler = window.onMouseMove.listen(onMouseMove);
-      dragStartPosition = new Point2(e.pageX, e.pageY);
+      dragStartPosition = new Point2(e.page.x, e.page.y);
     }
   }
   void onMouseUp(MouseEvent e) {
@@ -65,7 +65,7 @@ class UndockInitiator {
     mouseMoveHandler = null;
   }
   void onMouseMove(MouseEvent e) {
-    Point2 position = new Point2(e.pageX, e.pageY);
+    Point2 position = new Point2(e.page.x, e.page.y);
     num dx = position.x - dragStartPosition.x;
     num dy = position.y - dragStartPosition.y;
     num distance = sqrt(dx * dx + dy * dy);

--- a/lib/utils/undock_initiator.dart
+++ b/lib/utils/undock_initiator.dart
@@ -55,7 +55,7 @@ class UndockInitiator {
       _cancelSubscription(mouseMoveHandler);
       mouseUpHandler = window.onMouseUp.listen(onMouseUp);
       mouseMoveHandler = window.onMouseMove.listen(onMouseMove);
-      dragStartPosition = new Point2(e.$dom_pageX, e.$dom_pageY);
+      dragStartPosition = new Point2(e.pageX, e.pageY);
     }
   }
   void onMouseUp(MouseEvent e) {
@@ -65,7 +65,7 @@ class UndockInitiator {
     mouseMoveHandler = null;
   }
   void onMouseMove(MouseEvent e) {
-    Point2 position = new Point2(e.$dom_pageX, e.$dom_pageY);
+    Point2 position = new Point2(e.pageX, e.pageY);
     num dx = position.x - dragStartPosition.x;
     num dy = position.y - dragStartPosition.y;
     num distance = sqrt(dx * dx + dy * dy);
@@ -77,8 +77,8 @@ class UndockInitiator {
   }
   
   void _requestUndock(MouseEvent e) {
-    num dragOffsetX = dragStartPosition.x - element.$dom_offsetLeft;
-    num dragOffsetY = dragStartPosition.y - element.$dom_offsetTop;
+    num dragOffsetX = dragStartPosition.x - element.offsetLeft;
+    num dragOffsetY = dragStartPosition.y - element.offsetTop;
     Point2 dragOffset = new Point2(dragOffsetX, dragOffsetY);
     listener(e, dragOffset);
   }

--- a/lib/utils/undock_initiator.dart
+++ b/lib/utils/undock_initiator.dart
@@ -77,8 +77,8 @@ class UndockInitiator {
   }
   
   void _requestUndock(MouseEvent e) {
-    num dragOffsetX = dragStartPosition.x - element.offsetLeft;
-    num dragOffsetY = dragStartPosition.y - element.offsetTop;
+    num dragOffsetX = dragStartPosition.x - element.offset.left;
+    num dragOffsetY = dragStartPosition.y - element.offset.top;
     Point2 dragOffset = new Point2(dragOffsetX, dragOffsetY);
     listener(e, dragOffset);
   }

--- a/lib/utils/undock_initiator.dart
+++ b/lib/utils/undock_initiator.dart
@@ -55,7 +55,7 @@ class UndockInitiator {
       _cancelSubscription(mouseMoveHandler);
       mouseUpHandler = window.onMouseUp.listen(onMouseUp);
       mouseMoveHandler = window.onMouseMove.listen(onMouseMove);
-      dragStartPosition = new Point2(e.pageX, e.pageY);
+      dragStartPosition = new Point2(e.$dom_pageX, e.$dom_pageY);
     }
   }
   void onMouseUp(MouseEvent e) {
@@ -65,7 +65,7 @@ class UndockInitiator {
     mouseMoveHandler = null;
   }
   void onMouseMove(MouseEvent e) {
-    Point2 position = new Point2(e.pageX, e.pageY);
+    Point2 position = new Point2(e.$dom_pageX, e.$dom_pageY);
     num dx = position.x - dragStartPosition.x;
     num dy = position.y - dragStartPosition.y;
     num distance = sqrt(dx * dx + dy * dy);
@@ -77,8 +77,8 @@ class UndockInitiator {
   }
   
   void _requestUndock(MouseEvent e) {
-    num dragOffsetX = dragStartPosition.x - element.offsetLeft;
-    num dragOffsetY = dragStartPosition.y - element.offsetTop;
+    num dragOffsetX = dragStartPosition.x - element.$dom_offsetLeft;
+    num dragOffsetY = dragStartPosition.y - element.$dom_offsetTop;
     Point2 dragOffset = new Point2(dragOffsetX, dragOffsetY);
     listener(e, dragOffset);
   }

--- a/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
@@ -20,8 +20,8 @@ class EditorPanel extends PanelContainer {
   
   void resize(int _width, int _height) {
     super.resize(_width, _height);
-    int clientWidth = elementContent.clientWidth;
-    int clientHeight = elementContent.clientHeight;
+    int clientWidth = elementContent.client.width;
+    int clientHeight = elementContent.client.height;
     
     codeMirrorBase.style.width = "${clientWidth}px";
     codeMirrorBase.style.height = "${clientHeight}px";

--- a/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
@@ -20,8 +20,8 @@ class EditorPanel extends PanelContainer {
   
   void resize(int _width, int _height) {
     super.resize(_width, _height);
-    int clientWidth = elementContent.clientWidth;
-    int clientHeight = elementContent.clientHeight;
+    int clientWidth = elementContent.$dom_clientWidth;
+    int clientHeight = elementContent.$dom_clientHeight;
     
     codeMirrorBase.style.width = "${clientWidth}px";
     codeMirrorBase.style.height = "${clientHeight}px";

--- a/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/panels/editor_panel.dart
@@ -20,8 +20,8 @@ class EditorPanel extends PanelContainer {
   
   void resize(int _width, int _height) {
     super.resize(_width, _height);
-    int clientWidth = elementContent.$dom_clientWidth;
-    int clientHeight = elementContent.$dom_clientHeight;
+    int clientWidth = elementContent.clientWidth;
+    int clientHeight = elementContent.clientHeight;
     
     codeMirrorBase.style.width = "${clientWidth}px";
     codeMirrorBase.style.height = "${clientHeight}px";

--- a/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
@@ -42,7 +42,7 @@ class SpawnIDE {
   }
   
   void onResized(Event event) {
-    int headerHeight = header.clientHeight;
+    int headerHeight = header.client.height;
     dockManager.resize(window.innerWidth, window.innerHeight - headerHeight);
 //    dockManager.resize(600, 400);
   }

--- a/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
@@ -42,7 +42,7 @@ class SpawnIDE {
   }
   
   void onResized(Event event) {
-    int headerHeight = header.clientHeight;
+    int headerHeight = header.$dom_clientHeight;
     dockManager.resize(window.innerWidth, window.innerHeight - headerHeight);
 //    dockManager.resize(600, 400);
   }

--- a/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
+++ b/web/demos/dock_spawn_demo_ide/ide/spawn_ide.dart
@@ -42,7 +42,7 @@ class SpawnIDE {
   }
   
   void onResized(Event event) {
-    int headerHeight = header.$dom_clientHeight;
+    int headerHeight = header.clientHeight;
     dockManager.resize(window.innerWidth, window.innerHeight - headerHeight);
 //    dockManager.resize(600, 400);
   }


### PR DESCRIPTION
The Element abstract class had some changes made to it that deprecated the old way of calling getters and setters. The new way has a "$dom_" prefix.

This commit updates these calls for lib and for the IDE sample.
