### PR TITLE
Update for dart-1.1 breaking changes

### DIFF
--- a/dart/lib/dock_spawn.dart
+++ b/dart/lib/dock_spawn.dart
@@ -3,7 +3,7 @@ library dock_spawn;
 import 'dart:html';
 import 'dart:async';
 import 'dart:math';
-import 'dart:json' as json;
+import 'dart:convert' as JSON;
 
 part 'dialog/dialog.dart';
 part 'decorators/draggable_container.dart';

--- a/dart/lib/serialization/dock_graph_deserializer.dart
+++ b/dart/lib/serialization/dock_graph_deserializer.dart
@@ -8,7 +8,7 @@ class DockGraphDeserializer {
   DockGraphDeserializer(this.dockManager);
   
   DockModel deserialize(String _json) {
-    Map<String, Object> graphInfo = json.parse(_json);
+    Map<String, Object> graphInfo = JSON.decode(_json);
     DockModel model = new DockModel();
     model.rootNode = _buildGraph(graphInfo);
     return model;

--- a/dart/lib/serialization/dock_graph_serializer.dart
+++ b/dart/lib/serialization/dock_graph_serializer.dart
@@ -7,7 +7,7 @@ class DockGraphSerializer {
 
   String serialize(DockModel model) {
     var graphInfo = _buildGraphInfo(model.rootNode);
-    return json.stringify(graphInfo);
+    return JSON.encode(graphInfo);
   }
   
   Map<String, Object> _buildGraphInfo(DockNode node) {

--- a/dart/lib/utils/geometric_primitives.dart
+++ b/dart/lib/utils/geometric_primitives.dart
@@ -70,6 +70,13 @@ class Point2 {
   }
   
   String toString() => "[$x, $y]";
+  
+  int get hashCode {
+    int result = 17;
+    result = 37 * result + x.hashCode;
+    result = 37 * result + y.hashCode;
+    return result;
+  }
 }
 
 class Size {

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dock_spawn
-version: 1.0.1
+version: 1.0.3
 author: Ali Akbar Vathi <ali.akbar@gmail.com>
 description: Dock Spawn is a powerful web based dock layout engine.  Create dockable panel windows similar to Visual Studio IDE
 homepage: http://www.dockspawn.com/
 dependencies:
-  browser: '>=0.3.5+1 <0.3.6'
+  browser: '>= 0.9.1'


### PR DESCRIPTION
```
I couldn't get this nice looking library on pub repository compiled with the latest Dart 1.1. So this little commit comes up.

* Changed a dependent "browser" version to ">=0.9.1"
* Replaced deprecated calls like "json.stringfy" with "convert.something"
* Implemented hashCode() function for "Point2" class.
```

I'm not really sure I could just change "browser" version to 0.9.1. But "'>=0.3.5+1 <0.3.6'" was too restrictive to incorporate with other libraries.
